### PR TITLE
fix: update to latest zig version

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,12 +4,13 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "jetcommon",
-        .root_source_file = b.path("src/jetcommon.zig"),
-        .target = target,
-        .optimize = optimize,
-        .use_llvm = false,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/jetcommon.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const jetcommon_module = b.addModule("jetcommon", .{ .root_source_file = b.path("src/jetcommon.zig") });
@@ -21,9 +22,11 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(lib);
     const lib_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/jetcommon.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/jetcommon.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     lib_unit_tests.root_module.addImport("zul", zul_module);


### PR DESCRIPTION
Changes in src/jetcommon/fmt.zig have not been tested. It compiles, but am not sure how to move forward with testing.

https://github.com/karlseguin/zul/pull/11